### PR TITLE
Single element origin 

### DIFF
--- a/test/test_unified_diff.rb
+++ b/test/test_unified_diff.rb
@@ -105,4 +105,36 @@ class TestUnifiedDiff < MiniTest::Unit::TestCase
     @chunk = @diff.chunks.first
     assert_equal (1...2), @chunk.modified_range
   end
+
+  # For files:
+  # odd_line_original
+  # containing one line:
+  # foo
+  #
+  # and 
+  # odd_line_modified
+  # containing five lines:
+  # foo
+  # bar
+  # Baz
+  # qux
+  # quux
+  def test_handles_one_element_origin_chunk_range
+    diff = <<-DIFF.unindent
+      --- original.txt	2012-09-06 16:56:08.320483113 -0400
+      +++ modified.txt	2012-09-06 16:56:44.488483939 -0400
+      @@ -1 +1,5 @@
+       foo
+      +bar
+      +Baz
+      +qux
+      +quux
+    DIFF
+    @diff = UnifiedDiff.parse(diff)
+    @chunk = @diff.chunks.first
+    assert_equal (1...2), @chunk.original_range
+    assert_equal (1...6), @chunk.modified_range
+    assert_equal 0, @chunk.removed_lines.length
+    assert_equal 4, @chunk.added_lines.length
+  end
 end


### PR DESCRIPTION
Was using this on a project where CSV file with headers was being compared.  A file with no data failed to parse, so I recreated the scenario in a test and worked backwards from there.

This is a similar edge case to commit 128beb436bfc0f2e45670ffe4b0f8c8090016b06 and is caused by GNU diff providing the size only when it is not the default of 1.

Comments reflect the changes to the CHUNK_PATTERN.  I had to get @bclennox to help me with the REGEX.
