### PR TITLE
Support diffs without dates (a la git)

### DIFF
--- a/lib/unified_diff/diff.rb
+++ b/lib/unified_diff/diff.rb
@@ -4,7 +4,7 @@ module UnifiedDiff
     attr_reader :original, :original_file, :original_timestamp, :modified_file, :modified_timestamp, :chunks
     class UnifiedDiffException < Exception; end
 
-    FILE_PATTERN =      /(.*)\t'{2}?(.*)'{2}?/
+    FILE_PATTERN =      /([^\t\n]+)(?:\t'{2}?([^']+)'{2}?)?/
     OLD_FILE_PATTERN =  /--- #{FILE_PATTERN}/
     NEW_FILE_PATTERN =  /\+\+\+ #{FILE_PATTERN}/
     # Match assignment is tricky for CHUNK_PATTERN
@@ -48,9 +48,11 @@ module UnifiedDiff
       @original.each_line do |line|
         case line
         when OLD_FILE_PATTERN
-          @original_file, @original_timestamp = $1, Time.parse($2)
+          @original_file = $1
+          @original_timestamp = Time.parse($2) if $2
         when NEW_FILE_PATTERN
-          @modified_file, @modified_timestamp = $1, Time.parse($2)
+          @modified_file = $1
+          @modified_timestamp = Time.parse($2) if $2
         when CHUNK_PATTERN
           old_begin = $1.to_i
           if $2.nil?

--- a/test/test_unified_diff.rb
+++ b/test/test_unified_diff.rb
@@ -25,6 +25,42 @@ class TestUnifiedDiff < MiniTest::Unit::TestCase
     assert_equal Time.parse('2011-05-31 11:14:13.000000000 -0500'), @diff.original_timestamp
   end
 
+  def test_parses_original_information_with_single_quotes
+    original = <<-DIFF.unindent
+      --- original.txt	''2011-05-31 11:14:13.000000000 -0500''
+      +++ modified.txt	''2011-05-31 11:14:44.000000000 -0500''
+      @@ -1,5 +1,5 @@ Optional Text goes here.
+       foo
+       bar
+      -baz
+      +Baz
+       qux
+       quux
+    DIFF
+    diff = UnifiedDiff.parse(original)
+
+    assert_equal "modified.txt", diff.modified_file
+    assert_equal Time.parse('2011-05-31 11:14:44.000000000 -0500'), diff.modified_timestamp
+  end
+
+  def test_parses_original_information_without_dates
+    original = <<-DIFF.unindent
+      --- original.txt
+      +++ modified.txt
+      @@ -1,5 +1,5 @@ Optional Text goes here.
+       foo
+       bar
+      -baz
+      +Baz
+       qux
+       quux
+    DIFF
+    diff = UnifiedDiff.parse(original)
+
+    assert_equal "modified.txt", diff.modified_file
+    assert_nil diff.modified_timestamp
+  end
+
   def test_parses_modified_filename
     assert_equal "modified.txt", @diff.modified_file
     assert_equal Time.parse('2011-05-31 11:14:44.000000000 -0500'), @diff.modified_timestamp


### PR DESCRIPTION
Fix for issue #3 reported by @JasonHerr: Parse diffs without date, as are generated by git
