### PR TITLE
add support for 'no newline at end of file' lines

### DIFF
--- a/lib/unified_diff/chunk.rb
+++ b/lib/unified_diff/chunk.rb
@@ -58,7 +58,7 @@ module UnifiedDiff
       @raw_lines.select {|line| types.include?(line[0])}.map {|line| line[1..-1]}
     end
 
-   # Insert a new addition line into the list of lines for this chunk
+    # Insert a new addition line into the list of lines for this chunk
     #
     # @param [String] the line to be inserted (without '+' tag)
     # @return [Array] the new list of raw lines
@@ -80,6 +80,17 @@ module UnifiedDiff
     # @return [Array] the new list of raw lines
     def insert_unchanged(line)
       @raw_lines << " #{line}"
+    end
+
+    # Insert a no newline at end of file line into the list of lines for this
+    # chunk
+    #
+    # http://www.gnu.org/software/diffutils/manual/html_node/Incomplete-Lines.html
+    #
+    # @param [String] the line to be inserted (without '\' tag)
+    # @return [Array] the new list of raw lines
+    def insert_no_newline_at_eof(line)
+      @raw_lines << "\\#{line}"
     end
 
   end

--- a/lib/unified_diff/diff.rb
+++ b/lib/unified_diff/diff.rb
@@ -24,6 +24,7 @@ module UnifiedDiff
     ADDED_PATTERN =     /^\+(.*)/
     REMOVED_PATTERN =   /^-(.*)/
     UNCHANGED_PATTERN = /^ (.*)/
+    NO_NEWLINE_PATTERN = /^\\(\s+No\s+newline\s+at\s+end\s+of\s+file)$/
 
     # Create and parse a unified diff
     #
@@ -74,6 +75,8 @@ module UnifiedDiff
           @working_chunk.send(:insert_removal, $1)
         when UNCHANGED_PATTERN
           @working_chunk.send(:insert_unchanged, $1)
+        when NO_NEWLINE_PATTERN
+          @working_chunk.send(:insert_no_newline_at_eof, $1)
         else
           raise UnifiedDiffException.new("Unknown Line Type for Line:\n#{line}")
         end

--- a/test/test_chunk.rb
+++ b/test/test_chunk.rb
@@ -14,13 +14,15 @@ class TestChunk < MiniTest::Unit::TestCase
     @chunk.send(:insert_unchanged,"foo")
     @chunk.send(:insert_addition, "bar")
     @chunk.send(:insert_removal,  "baz")
-    assert_equal [" foo","+bar","-baz"], @chunk.raw_lines
+    @chunk.send(:insert_no_newline_at_eof,  "noel")
+    assert_equal [" foo","+bar","-baz", "\\noel"], @chunk.raw_lines
   end
 
   def test_original_lines
     @chunk.send(:insert_unchanged,"foo")
     @chunk.send(:insert_removal,"bar")
     @chunk.send(:insert_addition,"baz")
+    @chunk.send(:insert_no_newline_at_eof,  "noel")
     assert_equal %w{foo bar}, @chunk.original_lines
   end
 
@@ -28,18 +30,21 @@ class TestChunk < MiniTest::Unit::TestCase
     @chunk.send(:insert_unchanged,"foo")
     @chunk.send(:insert_removal,"bar")
     @chunk.send(:insert_addition,"baz")
+    @chunk.send(:insert_no_newline_at_eof,  "noel")
     assert_equal %w{foo baz}, @chunk.modified_lines
   end
 
   def test_removed_lines
     @chunk.send(:insert_removal,'foo')
     @chunk.send(:insert_unchanged, 'bar')
+    @chunk.send(:insert_no_newline_at_eof,  "noel")
     assert_equal ['foo'], @chunk.removed_lines
   end
 
   def test_added_lines
     @chunk.send(:insert_addition,'foo')
     @chunk.send(:insert_unchanged, 'bar')
+    @chunk.send(:insert_no_newline_at_eof,  "noel")
     assert_equal ['foo'], @chunk.added_lines
   end
 

--- a/test/test_unified_diff.rb
+++ b/test/test_unified_diff.rb
@@ -204,4 +204,25 @@ class TestUnifiedDiff < MiniTest::Unit::TestCase
     assert_equal (5...12), @chunk.original_range
     assert_equal (5...12), @chunk.modified_range
   end
+
+  def test_no_newline_at_eof
+    header = <<-HEADER.unindent
+      --- a   2014-02-26 16:19:13.000000000 -0800
+      +++ b   2014-02-26 16:19:13.000000000 -0800
+    HEADER
+
+    chunk = <<-'CHUNK'.unindent
+      @@ -1,1 +1,1 @@
+      -noel
+      \ No newline at end of file
+      +noll
+      \ No newline at end of file
+    CHUNK
+
+    @diff = UnifiedDiff.parse(header + chunk)
+    @chunk = @diff.chunks.first
+    assert_equal chunk, @chunk.to_s
+    assert_equal ["noel"], @chunk.original_lines
+    assert_equal ["noll"], @chunk.modified_lines
+  end
 end


### PR DESCRIPTION
This fixes an exception when one or more of the files involved in the diff doesn't end in a new line (the hunk has to also include the last line in the file).

http://www.gnu.org/software/diffutils/manual/html_node/Incomplete-Lines.html

Example diffs:

```
--- a   2014-02-28 21:32:47.573972366 -0800
+++ b   2014-02-28 21:32:47.573972366 -0800
@@ -1 +1 @@
-test
\ No newline at end of file
+tset
\ No newline at end of file
```

```
--- a   2014-02-28 21:41:18.553861291 -0800
+++ b   2014-02-28 21:41:18.553861291 -0800
@@ -1 +1 @@
-test
\ No newline at end of file
+tset
```

```
--- a   2014-02-28 21:41:29.452561722 -0800
+++ b   2014-02-28 21:41:29.453561786 -0800
@@ -1 +1 @@
-test
+tset
\ No newline at end of file
```

These lines aren't really part of the original or modified files, but they should be part of the chunk's raw lines.
