### PR TITLE
only match new/old file pattern at the beginning of a line

### DIFF
--- a/lib/unified_diff/diff.rb
+++ b/lib/unified_diff/diff.rb
@@ -5,8 +5,8 @@ module UnifiedDiff
     class UnifiedDiffException < Exception; end
 
     FILE_PATTERN =      /([^\t\n]+)(?:\t'{2}?([^']+)'{2}?)?/
-    OLD_FILE_PATTERN =  /--- #{FILE_PATTERN}/
-    NEW_FILE_PATTERN =  /\+\+\+ #{FILE_PATTERN}/
+    OLD_FILE_PATTERN =  /^--- #{FILE_PATTERN}/
+    NEW_FILE_PATTERN =  /^\+\+\+ #{FILE_PATTERN}/
     # Match assignment is tricky for CHUNK_PATTERN
     # $1 and $3 are static, but $2 and $4 can be nil
     #

--- a/test/test_unified_diff.rb
+++ b/test/test_unified_diff.rb
@@ -207,8 +207,8 @@ class TestUnifiedDiff < MiniTest::Unit::TestCase
 
   def test_no_newline_at_eof
     header = <<-HEADER.unindent
-      --- a   2014-02-26 16:19:13.000000000 -0800
-      +++ b   2014-02-26 16:19:13.000000000 -0800
+      --- a	2014-02-26 16:19:13.000000000 -0800
+      +++ b	2014-02-26 16:19:13.000000000 -0800
     HEADER
 
     chunk = <<-'CHUNK'.unindent
@@ -225,4 +225,47 @@ class TestUnifiedDiff < MiniTest::Unit::TestCase
     assert_equal ["noel"], @chunk.original_lines
     assert_equal ["noll"], @chunk.modified_lines
   end
+
+  def test_pluses
+    header = <<-HEADER.unindent
+      --- a	2014-07-26 21:44:41.068596411 -0700
+      +++ b	2014-08-03 05:18:34.411245070 -0700
+    HEADER
+
+    chunk = <<-'CHUNK'.unindent
+      @@ -0,0 +1,5 @@
+      ++++++++ ++++++ +++
+      ++ some heading
+      + stuff +++++++++ stuff
+      ++++ a
+      +some body
+    CHUNK
+
+    @diff = UnifiedDiff.parse(header + chunk)
+    @chunk = @diff.chunks.first
+    assert_equal chunk, @chunk.to_s
+    assert_equal 5, @chunk.added_lines.length
+  end
+
+  def test_hyphens
+    header = <<-HEADER.unindent
+      --- a	2014-07-26 21:44:41.068596411 -0700
+      +++ b	2014-08-03 05:18:34.411245070 -0700
+    HEADER
+
+    chunk = <<-'CHUNK'.unindent
+      @@ -1,5 +0,0 @@
+      -------- ------ ---
+      -- some heading
+      - stuff --------- stuff
+      ---- a
+      -some body
+    CHUNK
+
+    @diff = UnifiedDiff.parse(header + chunk)
+    @chunk = @diff.chunks.first
+    assert_equal chunk, @chunk.to_s
+    assert_equal 5, @chunk.removed_lines.length
+  end
+
 end


### PR DESCRIPTION
Some diff lines that include the patterns "--- " or "+++ " are being mistakenly identified as the diff header (new/old file). Since these lines don't get include in the chunk, there ends up being a mismatch being the header and the contents which prevents a chunk from being applied.

```
   chunk = <<-'CHUNK'.unindent
      @@ -0,0 +1,5 @@
      ++++++++ ++++++ +++
      ++ some heading
      + stuff +++++++++ stuff
      ++++ a
      +some body
    CHUNK

    @diff = UnifiedDiff.parse(header + chunk)
    @chunk = @diff.chunks.first
    puts @chunk

> cat test.diff
--- test.out
+++ test.out
@@ -0,0 +1,5 @@
++ some heading
+some body

> patch < test.diff
patching file test.out
patch: **** malformed patch at line 5:  
```
