### PR TITLE
Updates to unified_diff (See details below).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+bundler_args: --retry=3 --jobs=3
+cache: bundler
+language: ruby
+sudo: false
+rvm:
+  - 1.9.3
+  - 2.0.0
+  - 2.1
+  - 2.2
+  - jruby-19mode
+  - jruby-head
+  - rbx-2
+  - ruby-head
+env:
+  global:
+    - JRUBY_OPTS="-J-Xmx1024M --debug"
+matrix:
+  allow_failures:
+    - rvm: 1.9.3
+    - rvm: jruby-19mode
+    - rvm: jruby-head
+    - rvm: rbx-2
+    - rvm: ruby-head
+  fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "http://rubygems.org"
 
 group :development do
-  gem 'minitest', "~> 5.4.0"
+  gem 'minitest', "~> 5.5.0"
   gem "jeweler", "~> 2.0.1"
   gem 'simplecov', "~> 0.9.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
     json (1.8.1)
     jwt (1.0.0)
     mini_portile (0.6.0)
-    minitest (5.4.0)
+    minitest (5.5.1)
     multi_json (1.10.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
@@ -59,5 +59,5 @@ PLATFORMS
 
 DEPENDENCIES
   jeweler (~> 2.0.1)
-  minitest (~> 5.4.0)
+  minitest (~> 5.5.0)
   simplecov (~> 0.9.0)

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2011 Ryan Neufeld
+Copyright (c) 2015 Ryan Neufeld
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/README.md
+++ b/README.md
@@ -1,13 +1,19 @@
-= unified_diff
+# unified_diff
 
-unified_diff is a simple library to parse unified diffs into clean ruby objects. 
+[![Gem Version](http://img.shields.io/gem/v/unified_diff.svg)][gem]
+[![Build Status](http://img.shields.io/travis/rkneufeld/unified_diff.svg)][travis]
 
-Simply UnifiedDiff.parse(diff_contents) and you'll get back a Diff object with metadata from your diff as well as a list of chunks accesible via Diff#chunks.
+[gem]: https://rubygems.org/gems/unified_diff
+[travis]: http://travis-ci.org/rkneufeld/unified_diff
+
+unified_diff is a simple library to parse unified diffs into clean ruby objects.
+
+Simply `UnifiedDiff.parse(diff_contents)` and you'll get back a `Diff` object with metadata from your diff as well as a list of chunks accesible via `Diff#chunks`.
 
 More features to follow.
 
-== Contributing to unified_diff
- 
+## Contributing to unified_diff
+
 * Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet
 * Check out the issue tracker to make sure someone already hasn't requested it and/or contributed it
 * Fork the project
@@ -16,8 +22,7 @@ More features to follow.
 * Make sure to add tests for it. This is important so I don't break it in a future version unintentionally.
 * Please try not to mess with the Rakefile, version, or history. If you want to have your own version, or is otherwise necessary, that is fine, but please isolate to its own commit so I can cherry-pick around it.
 
-== Copyright
+## Copyright
 
-Copyright (c) 2011 Ryan Neufeld. See LICENSE.txt for
+Copyright (c) 2015 Ryan Neufeld. See LICENSE.txt for
 further details.
-


### PR DESCRIPTION
- Convert README.rdoc to README.md
- Add version and travis svg badges to README.md
- Update Copyright year to 2015
- Update Minitest to 5.5.1
- Add a `.travis.yml` from [this sample .travis.yml](https://gist.github.com/JuanitoFatas/55e259d0efcfcd73dde1)
